### PR TITLE
Add space between "and" and date

### DIFF
--- a/src/app/repositories/[name]/page.tsx
+++ b/src/app/repositories/[name]/page.tsx
@@ -17,7 +17,7 @@ export default async function RepositoryDetail({ params }: { params: { name: str
         <h1>{repo.name}</h1>
         <p>
           This repository contains {repo.stats.total_packages} packages published between{" "}
-          {format(earliest, "dd/MM/yyyy")}
+          {format(earliest, "dd/MM/yyyy")}{" "}
           and {format(latest, "dd/MM/yyyy")}. The compressed size of this repository is{" "}
           {byteSize(repo.size, { units: "iec", precision: 1 }).toString()}
         </p>


### PR DESCRIPTION
Add a space between "and" and the date to avoid things like "between 10/09/2023and 10/09/2023."